### PR TITLE
Fails to convert laminas to psr when aminas content is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#2](https://github.com/laminas/laminas-psr7bridge/pull/2) Fixes error on attempt to convert laminas-http request with null body content
 
 ## 1.2.0 - 2018-12-20
 

--- a/src/Psr7ServerRequest.php
+++ b/src/Psr7ServerRequest.php
@@ -65,7 +65,9 @@ final class Psr7ServerRequest
     public static function fromLaminas(LaminasRequest $laminasRequest)
     {
         $body = new Stream('php://memory', 'wb+');
-        $body->write($laminasRequest->getContent());
+        if ($laminasRequest->getContent() !== null) {
+            $body->write($laminasRequest->getContent());
+        }
 
         $headers = empty($laminasRequest->getHeaders()) ? [] : $laminasRequest->getHeaders()->toArray();
         $query   = empty($laminasRequest->getQuery()) ? [] : $laminasRequest->getQuery()->toArray();

--- a/test/Psr7ServerRequestTest.php
+++ b/test/Psr7ServerRequestTest.php
@@ -568,4 +568,13 @@ class Psr7ServerRequestTest extends TestCase
         $this->expectExceptionMessage(sprintf('Call to private %s::__construct', Psr7ServerRequest::class));
         new Psr7ServerRequest();
     }
+
+    public function testFromLaminasCanHandleNullContent()
+    {
+        $laminasRequest = new LaminasRequest();
+        $laminasRequest->setContent(null);
+
+        $psr7Request = Psr7ServerRequest::fromLaminas($laminasRequest);
+        $this->assertEmpty($psr7Request->getBody()->getContents());
+    }
 }


### PR DESCRIPTION
@Xerkus said that laminas request can be null and he is right when writing tests I somehow got null end this errored about null written to a stream