### PR TITLE
PHP 8.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,41 +12,25 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 5.6
-      env:
-        - DEPS=lowest
-    - php: 5.6
-      env:
-        - DEPS=latest
-    - php: 7
-      env:
-        - DEPS=lowest
-    - php: 7
-      env:
-        - DEPS=latest
-    - php: 7.1
-      env:
-        - DEPS=lowest
-    - php: 7.1
-      env:
-        - DEPS=latest
-        - CS_CHECK=true
-        - TEST_COVERAGE=true
-    - php: 7.2
-      env:
-        - DEPS=lowest
-    - php: 7.2
-      env:
-        - DEPS=latest
     - php: 7.3
       env:
         - DEPS=lowest
+        - CS_CHECK=true
+        - TEST_COVERAGE=true
     - php: 7.3
       env:
         - DEPS=latest
     - php: 7.4
       env:
         - DEPS=latest
+    - php: nightly
+      env:
+        - DEPS=lowest
+        - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
+    - php: nightly
+      env:
+       - DEPS=latest
+       - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "extra": {
     },
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.3 || ~8.0.0",
         "laminas/laminas-diactoros": "^1.7 || ^2.0",
         "laminas/laminas-http": "^2.11",
         "laminas/laminas-zendframework-bridge": "^1.0",
@@ -31,7 +31,7 @@
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",
-        "phpunit/phpunit": "^5.7.15 || ^6.5.6 || ^7.5.20"
+        "phpunit/phpunit": "^9.4.1"
     },
     "conflict": {
         "laminas/laminas-stdlib": "< 3.2.1"

--- a/test/Psr7ResponseTest.php
+++ b/test/Psr7ResponseTest.php
@@ -55,7 +55,7 @@ class Psr7ResponseTest extends TestCase
         $laminasHeaders = $laminasResponse->getHeaders()->toArray();
         foreach ($headers as $type => $values) {
             foreach ($values as $value) {
-                $this->assertContains($value, $laminasHeaders[$type]);
+                $this->assertStringContainsString($value, $laminasHeaders[$type]);
             }
         }
     }
@@ -79,7 +79,7 @@ class Psr7ResponseTest extends TestCase
         $laminasHeaders = $laminasResponse->getHeaders()->toArray();
         foreach ($headers as $type => $values) {
             foreach ($values as $value) {
-                $this->assertContains($value, $laminasHeaders[$type]);
+                $this->assertStringContainsString($value, $laminasHeaders[$type]);
             }
         }
     }
@@ -103,7 +103,7 @@ class Psr7ResponseTest extends TestCase
         $laminasHeaders = $laminasResponse->getHeaders()->toArray();
         foreach ($headers as $type => $values) {
             foreach ($values as $value) {
-                $this->assertContains($value, $laminasHeaders[$type]);
+                $this->assertStringContainsString($value, $laminasHeaders[$type]);
             }
         }
     }
@@ -133,7 +133,7 @@ class Psr7ResponseTest extends TestCase
         $laminasHeaders = $laminasResponse->getHeaders()->toArray();
         foreach ($psr7Response->getHeaders() as $type => $values) {
             foreach ($values as $value) {
-                $this->assertContains($value, $laminasHeaders[$type]);
+                $this->assertStringContainsString($value, $laminasHeaders[$type]);
             }
         }
     }


### PR DESCRIPTION
Signed-off-by: Oliver Peters <oliver_pet@web.de>

|    Q          |   A
|-------------- | ------
| New Feature   | yes

### Description
drop support for PHP versions < 7.3
add support for PHP 8.0
update PhpUnit to 9.4.1