### PR TITLE
Drop `laminas/laminas-zendframework-bridge` and `zendframework/*` compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
         "php": "^7.3 || ~8.0.0 || ~8.1.0",
         "laminas/laminas-diactoros": "^1.7 || ^2.0",
         "laminas/laminas-http": "^2.15",
-        "laminas/laminas-zendframework-bridge": "^1.0",
         "psr/http-message": "^1.0"
     },
     "require-dev": {
@@ -36,7 +35,8 @@
         "vimeo/psalm": "^4.11"
     },
     "conflict": {
-        "laminas/laminas-stdlib": "< 3.2.1"
+        "laminas/laminas-stdlib": "< 3.2.1",
+        "zendframework/zend-psr7bridge": "*"
     },
     "autoload": {
         "psr-4": {
@@ -58,8 +58,5 @@
         "test": "phpunit --colors=always",
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml",
         "static-analysis": "psalm --shepherd --stats"
-    },
-    "replace": {
-        "zendframework/zend-psr7bridge": "^1.2.0"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5d72a9429b5f057cc93e9a1b32f81374",
+    "content-hash": "224d5e589905a584484d96653de375e8",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -4592,6 +4592,7 @@
                 "issues": "https://github.com/webmozart/path-util/issues",
                 "source": "https://github.com/webmozart/path-util/tree/2.3.0"
             },
+            "abandoned": "symfony/filesystem",
             "time": "2015-12-17T08:42:14+00:00"
         }
     ],


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description


Increase performance by removing a compatibility layer while **not** introducing breaking changes.

This follow the process described in details in:

https://github.com/laminas/technical-steering-committee/blob/main/meetings/minutes/2021-08-02-TSC-Minutes.md#remove-laminaslaminas-zendframework-bridge-dependency-from-our-packages
