### PR TITLE
Drop php 8.0

### DIFF
--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -1,6 +1,1 @@
-{
-  "ignore_php_platform_requirements": {
-    "8.1": false,
-    "8.2": true
-  }
-}
+{}

--- a/composer.json
+++ b/composer.json
@@ -30,15 +30,15 @@
     },
     "require": {
         "php": "~8.1.0 || ~8.2.0",
-        "laminas/laminas-diactoros": "^2.0",
-        "laminas/laminas-http": "^2.18",
-        "psr/http-message": "^1.0"
+        "laminas/laminas-diactoros": "^2.25.2",
+        "laminas/laminas-http": "^2.18.0",
+        "psr/http-message": "^1.1"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~2.5.0",
         "phpunit/phpunit": "^9.5.27",
         "psalm/plugin-phpunit": "^0.18.4",
-        "vimeo/psalm": "^5.4"
+        "vimeo/psalm": "^5.9.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -40,10 +40,6 @@
         "psalm/plugin-phpunit": "^0.18.4",
         "vimeo/psalm": "^5.4"
     },
-    "conflict": {
-        "laminas/laminas-stdlib": "< 3.2.1",
-        "zendframework/zend-psr7bridge": "*"
-    },
     "autoload": {
         "psr-4": {
             "Laminas\\Psr7Bridge\\": "src/"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "config": {
         "sort-packages": true,
         "platform": {
-            "php": "8.0.99"
+            "php": "8.1.99"
         },
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
@@ -29,7 +29,7 @@
     "extra": {
     },
     "require": {
-        "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
+        "php": "~8.1.0 || ~8.2.0",
         "laminas/laminas-diactoros": "^2.0",
         "laminas/laminas-http": "^2.18",
         "psr/http-message": "^1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5ac5e989802496e80c8748dca2730771",
+    "content-hash": "c7752b8b31da25ad454a277b1a6ac5da",
     "packages": [
         {
             "name": "laminas/laminas-diactoros",
-            "version": "2.25.1",
+            "version": "2.25.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-diactoros.git",
-                "reference": "13f45e5ba09c9b27752247d3be186fc49c2ca3a5"
+                "reference": "9f3f4bf5b99c9538b6f1dbcc20f6fec357914f9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/13f45e5ba09c9b27752247d3be186fc49c2ca3a5",
-                "reference": "13f45e5ba09c9b27752247d3be186fc49c2ca3a5",
+                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/9f3f4bf5b99c9538b6f1dbcc20f6fec357914f9e",
+                "reference": "9f3f4bf5b99c9538b6f1dbcc20f6fec357914f9e",
                 "shasum": ""
             },
             "require": {
@@ -101,7 +101,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-04-08T00:31:34+00:00"
+            "time": "2023-04-17T15:44:17+00:00"
         },
         {
             "name": "laminas/laminas-escaper",
@@ -378,30 +378,30 @@
         },
         {
             "name": "laminas/laminas-stdlib",
-            "version": "3.16.1",
+            "version": "3.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-stdlib.git",
-                "reference": "f4f773641807c7ccee59b758bfe4ac4ba33ecb17"
+                "reference": "dd35c868075bad80b6718959740913e178eb4274"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/f4f773641807c7ccee59b758bfe4ac4ba33ecb17",
-                "reference": "f4f773641807c7ccee59b758bfe4ac4ba33ecb17",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/dd35c868075bad80b6718959740913e178eb4274",
+                "reference": "dd35c868075bad80b6718959740913e178eb4274",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
+                "php": "~8.1.0 || ~8.2.0"
             },
             "conflict": {
                 "zendframework/zend-stdlib": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "^2.4.0",
-                "phpbench/phpbench": "^1.2.7",
-                "phpunit/phpunit": "^9.5.26",
-                "psalm/plugin-phpunit": "^0.18.0",
-                "vimeo/psalm": "^5.0.0"
+                "laminas/laminas-coding-standard": "^2.5",
+                "phpbench/phpbench": "^1.2.9",
+                "phpunit/phpunit": "^10.0.16",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "vimeo/psalm": "^5.8"
             },
             "type": "library",
             "autoload": {
@@ -433,7 +433,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-12-03T18:48:01+00:00"
+            "time": "2023-03-20T13:51:37+00:00"
         },
         {
             "name": "laminas/laminas-uri",
@@ -1312,30 +1312,30 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.5.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^8.1"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9 || ^11",
+                "doctrine/coding-standard": "^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.16 || ^1",
-                "phpstan/phpstan": "^1.4",
-                "phpstan/phpstan-phpunit": "^1",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "vimeo/psalm": "^4.30 || ^5.4"
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^1.9.4",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5.27",
+                "vimeo/psalm": "^5.4"
             },
             "type": "library",
             "autoload": {
@@ -1362,7 +1362,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
+                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
             },
             "funding": [
                 {
@@ -1378,7 +1378,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-30T00:15:36+00:00"
+            "time": "2022-12-30T00:23:10+00:00"
         },
         {
             "name": "felixfbecker/advanced-json-rpc",
@@ -3762,20 +3762,21 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.0.19",
+            "version": "v6.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "c3ebc83d031b71c39da318ca8b7a07ecc67507ed"
+                "reference": "3582d68a64a86ec25240aaa521ec8bc2342b369b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/c3ebc83d031b71c39da318ca8b7a07ecc67507ed",
-                "reference": "c3ebc83d031b71c39da318ca8b7a07ecc67507ed",
+                "url": "https://api.github.com/repos/symfony/console/zipball/3582d68a64a86ec25240aaa521ec8bc2342b369b",
+                "reference": "3582d68a64a86ec25240aaa521ec8bc2342b369b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.1|^3",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/service-contracts": "^1.1|^2|^3",
                 "symfony/string": "^5.4|^6.0"
@@ -3832,12 +3833,12 @@
             "homepage": "https://symfony.com",
             "keywords": [
                 "cli",
-                "command line",
+                "command-line",
                 "console",
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.0.19"
+                "source": "https://github.com/symfony/console/tree/v6.2.8"
             },
             "funding": [
                 {
@@ -3853,24 +3854,91 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:36:10+00:00"
+            "time": "2023-03-29T21:42:15+00:00"
         },
         {
-            "name": "symfony/filesystem",
-            "version": "v6.0.19",
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/filesystem.git",
-                "reference": "3d49eec03fda1f0fc19b7349fbbe55ebc1004214"
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/3d49eec03fda1f0fc19b7349fbbe55ebc1004214",
-                "reference": "3d49eec03fda1f0fc19b7349fbbe55ebc1004214",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e",
+                "reference": "e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.3-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-03-01T10:25:55+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v6.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "82b6c62b959f642d000456f08c6d219d749215b3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/82b6c62b959f642d000456f08c6d219d749215b3",
+                "reference": "82b6c62b959f642d000456f08c6d219d749215b3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-mbstring": "~1.8"
             },
@@ -3900,7 +3968,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v6.0.19"
+                "source": "https://github.com/symfony/filesystem/tree/v6.2.7"
             },
             "funding": [
                 {
@@ -3916,7 +3984,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-20T17:44:14+00:00"
+            "time": "2023-02-14T08:44:56+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -4250,20 +4318,20 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.0.2",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "d78d39c1599bd1188b8e26bb341da52c3c6d8a66"
+                "reference": "a8c9cedf55f314f3a186041d19537303766df09a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d78d39c1599bd1188b8e26bb341da52c3c6d8a66",
-                "reference": "d78d39c1599bd1188b8e26bb341da52c3c6d8a66",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/a8c9cedf55f314f3a186041d19537303766df09a",
+                "reference": "a8c9cedf55f314f3a186041d19537303766df09a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
                 "psr/container": "^2.0"
             },
             "conflict": {
@@ -4275,7 +4343,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "3.3-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -4285,7 +4353,10 @@
             "autoload": {
                 "psr-4": {
                     "Symfony\\Contracts\\Service\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -4312,7 +4383,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.0.2"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.2.1"
             },
             "funding": [
                 {
@@ -4328,24 +4399,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-30T19:17:58+00:00"
+            "time": "2023-03-01T10:32:47+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v6.0.19",
+            "version": "v6.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "d9e72497367c23e08bf94176d2be45b00a9d232a"
+                "reference": "193e83bbd6617d6b2151c37fff10fa7168ebddef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/d9e72497367c23e08bf94176d2be45b00a9d232a",
-                "reference": "d9e72497367c23e08bf94176d2be45b00a9d232a",
+                "url": "https://api.github.com/repos/symfony/string/zipball/193e83bbd6617d6b2151c37fff10fa7168ebddef",
+                "reference": "193e83bbd6617d6b2151c37fff10fa7168ebddef",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-intl-grapheme": "~1.0",
                 "symfony/polyfill-intl-normalizer": "~1.0",
@@ -4357,6 +4428,7 @@
             "require-dev": {
                 "symfony/error-handler": "^5.4|^6.0",
                 "symfony/http-client": "^5.4|^6.0",
+                "symfony/intl": "^6.2",
                 "symfony/translation-contracts": "^2.0|^3.0",
                 "symfony/var-exporter": "^5.4|^6.0"
             },
@@ -4397,7 +4469,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.0.19"
+                "source": "https://github.com/symfony/string/tree/v6.2.8"
             },
             "funding": [
                 {
@@ -4413,7 +4485,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:36:10+00:00"
+            "time": "2023-03-20T16:06:02+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -4691,11 +4763,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
+        "php": "~8.1.0 || ~8.2.0"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "8.0.99"
+        "php": "8.1.99"
     },
     "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c7752b8b31da25ad454a277b1a6ac5da",
+    "content-hash": "f6339666237fdf445620110318f91e34",
     "packages": [
         {
             "name": "laminas/laminas-diactoros",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.1.0@4defa177c89397c5e14737a80fe4896584130674">
+<files psalm-version="5.9.0@8b9ad1eb9e8b7d3101f949291da2b9f7767cd163">
   <file src="src/Laminas/Request.php">
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$value</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$name</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$value</code>
       <code>$values</code>
     </MixedAssignment>
-    <PossiblyInvalidMethodCall occurrences="2">
+    <PossiblyInvalidMethodCall>
       <code>addHeader</code>
       <code>addHeaderLine</code>
     </PossiblyInvalidMethodCall>
-    <PossiblyUndefinedMethod occurrences="2">
+    <PossiblyUndefinedMethod>
       <code>addHeader</code>
       <code>addHeaderLine</code>
     </PossiblyUndefinedMethod>
-    <PropertyNotSetInConstructor occurrences="8">
+    <PropertyNotSetInConstructor>
       <code>Request</code>
       <code>Request</code>
       <code>Request</code>
@@ -31,41 +31,45 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Psr7Response.php">
-    <MixedArgument occurrences="3">
+    <MixedArgument>
       <code>$uri</code>
       <code>func_get_args()</code>
       <code>func_get_args()</code>
     </MixedArgument>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$uri</code>
     </MixedAssignment>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument>
       <code>$uri</code>
     </PossiblyInvalidArgument>
-    <PossiblyInvalidCast occurrences="1">
+    <PossiblyInvalidCast>
       <code>$uri</code>
     </PossiblyInvalidCast>
+    <PossiblyUnusedMethod>
+      <code>fromZend</code>
+      <code>toZend</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="src/Psr7ServerRequest.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>is_array($upload)</code>
     </DocblockTypeContradiction>
-    <InvalidReturnStatement occurrences="1">
+    <InvalidReturnStatement>
       <code>$uploadedFiles</code>
     </InvalidReturnStatement>
-    <InvalidReturnType occurrences="1">
+    <InvalidReturnType>
       <code>UploadedFile[]|UploadedFile</code>
     </InvalidReturnType>
-    <MixedArgument occurrences="15">
+    <MixedArgument>
       <code>$files</code>
-      <code>$files['error']</code>
-      <code>$files['name']</code>
-      <code>$files['size']</code>
-      <code>$files['tmp_name']</code>
-      <code>$files['type']</code>
+      <code><![CDATA[$files['error']]]></code>
+      <code><![CDATA[$files['name']]]></code>
+      <code><![CDATA[$files['size']]]></code>
+      <code><![CDATA[$files['tmp_name']]]></code>
+      <code><![CDATA[$files['type']]]></code>
       <code>$headers</code>
-      <code>$laminasRequest-&gt;getContent()</code>
-      <code>$laminasRequest-&gt;getServer()</code>
+      <code><![CDATA[$laminasRequest->getContent()]]></code>
+      <code><![CDATA[$laminasRequest->getServer()]]></code>
       <code>$post</code>
       <code>$query</code>
       <code>$upload</code>
@@ -73,47 +77,51 @@
       <code>func_get_args()</code>
       <code>func_get_args()</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
-      <code>$psr7Request-&gt;getUploadedFiles()</code>
+    <MixedArgumentTypeCoercion>
+      <code><![CDATA[$psr7Request->getUploadedFiles()]]></code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment>
       <code>$files</code>
       <code>$headers</code>
       <code>$post</code>
       <code>$query</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="3">
+    <MixedMethodCall>
       <code>toArray</code>
       <code>toArray</code>
       <code>toArray</code>
     </MixedMethodCall>
-    <PossiblyInvalidArgument occurrences="2">
-      <code>$psr7Request-&gt;getParsedBody() ?: []</code>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$psr7Request->getParsedBody() ?: []]]></code>
       <code>self::convertFilesToUploaded($files)</code>
     </PossiblyInvalidArgument>
-    <PossiblyInvalidMethodCall occurrences="2">
+    <PossiblyInvalidMethodCall>
       <code>getArrayCopy</code>
       <code>toArray</code>
     </PossiblyInvalidMethodCall>
-    <PossiblyUndefinedMethod occurrences="1">
+    <PossiblyUndefinedMethod>
       <code>toArray</code>
     </PossiblyUndefinedMethod>
+    <PossiblyUnusedMethod>
+      <code>fromZend</code>
+      <code>toZend</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/Laminas/RequestTest.php">
-    <MissingReturnType occurrences="1">
+    <MissingReturnType>
       <code>testConstructor</code>
     </MissingReturnType>
   </file>
   <file src="test/Psr7ResponseTest.php">
-    <InaccessibleMethod occurrences="1">
+    <InaccessibleMethod>
       <code>new Psr7Response()</code>
     </InaccessibleMethod>
-    <MissingReturnType occurrences="2">
+    <MissingReturnType>
       <code>testConvertedHeadersAreInstanceOfTheirAppropriateClasses</code>
       <code>testPrivateConstruct</code>
     </MissingReturnType>
-    <MixedArgument occurrences="7">
+    <MixedArgument>
       <code>$laminasHeaders[$type]</code>
       <code>$laminasHeaders[$type]</code>
       <code>$laminasHeaders[$type]</code>
@@ -122,7 +130,7 @@
       <code>$value</code>
       <code>$value</code>
     </MixedArgument>
-    <MixedAssignment occurrences="6">
+    <MixedAssignment>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
@@ -130,24 +138,24 @@
       <code>$values</code>
       <code>$values</code>
     </MixedAssignment>
-    <PossiblyUndefinedMethod occurrences="1">
+    <PossiblyUndefinedMethod>
       <code>$cookies</code>
     </PossiblyUndefinedMethod>
   </file>
   <file src="test/Psr7ServerRequestTest.php">
-    <InaccessibleMethod occurrences="1">
+    <InaccessibleMethod>
       <code>new Psr7ServerRequest()</code>
     </InaccessibleMethod>
-    <MissingReturnType occurrences="5">
+    <MissingReturnType>
       <code>testBaseUrlFromGlobal</code>
       <code>testFromLaminasCanHandleNullContent</code>
       <code>testFromLaminasConvertsCookies</code>
       <code>testPrivateConstruct</code>
       <code>testServerParams</code>
     </MissingReturnType>
-    <MixedArgument occurrences="31">
-      <code>$laminasRequest-&gt;getFiles()</code>
-      <code>$laminasRequest-&gt;getPost()</code>
+    <MixedArgument>
+      <code><![CDATA[$laminasRequest->getFiles()]]></code>
+      <code><![CDATA[$laminasRequest->getPost()]]></code>
       <code>$laminas[$name]</code>
       <code>$psr7[$name]</code>
       <code>$test</code>
@@ -178,24 +186,24 @@
       <code>$upload[1]</code>
       <code>$upload[1]</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="15">
-      <code>$upload['error']</code>
-      <code>$upload['name']</code>
-      <code>$upload['size']</code>
-      <code>$upload['tmp_name']</code>
-      <code>$upload['type']</code>
-      <code>$upload[0]['error']</code>
-      <code>$upload[0]['name']</code>
-      <code>$upload[0]['size']</code>
-      <code>$upload[0]['tmp_name']</code>
-      <code>$upload[0]['type']</code>
-      <code>$upload[1]['error']</code>
-      <code>$upload[1]['name']</code>
-      <code>$upload[1]['size']</code>
-      <code>$upload[1]['tmp_name']</code>
-      <code>$upload[1]['type']</code>
+    <MixedArrayAccess>
+      <code><![CDATA[$upload['error']]]></code>
+      <code><![CDATA[$upload['name']]]></code>
+      <code><![CDATA[$upload['size']]]></code>
+      <code><![CDATA[$upload['tmp_name']]]></code>
+      <code><![CDATA[$upload['type']]]></code>
+      <code><![CDATA[$upload[0]['error']]]></code>
+      <code><![CDATA[$upload[0]['name']]]></code>
+      <code><![CDATA[$upload[0]['size']]]></code>
+      <code><![CDATA[$upload[0]['tmp_name']]]></code>
+      <code><![CDATA[$upload[0]['type']]]></code>
+      <code><![CDATA[$upload[1]['error']]]></code>
+      <code><![CDATA[$upload[1]['name']]]></code>
+      <code><![CDATA[$upload[1]['size']]]></code>
+      <code><![CDATA[$upload[1]['tmp_name']]]></code>
+      <code><![CDATA[$upload[1]['type']]]></code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="6">
+    <MixedAssignment>
       <code>$test</code>
       <code>$test</code>
       <code>$test</code>
@@ -203,7 +211,7 @@
       <code>$upload</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="20">
+    <MixedMethodCall>
       <code>fromArray</code>
       <code>fromArray</code>
       <code>fromArray</code>
@@ -225,7 +233,7 @@
       <code>getFieldValue</code>
       <code>getFieldValue</code>
     </MixedMethodCall>
-    <PossiblyInvalidMethodCall occurrences="34">
+    <PossiblyInvalidMethodCall>
       <code>addHeader</code>
       <code>addHeaders</code>
       <code>get</code>
@@ -261,7 +269,7 @@
       <code>has</code>
       <code>has</code>
     </PossiblyInvalidMethodCall>
-    <PossiblyUndefinedMethod occurrences="28">
+    <PossiblyUndefinedMethod>
       <code>addHeader</code>
       <code>addHeaders</code>
       <code>get</code>
@@ -291,11 +299,11 @@
       <code>has</code>
       <code>has</code>
     </PossiblyUndefinedMethod>
-    <RedundantCastGivenDocblockType occurrences="2">
-      <code>(string) $laminasRequest-&gt;getContent()</code>
-      <code>(string) $laminasRequest-&gt;getContent()</code>
+    <RedundantCastGivenDocblockType>
+      <code><![CDATA[(string) $laminasRequest->getContent()]]></code>
+      <code><![CDATA[(string) $laminasRequest->getContent()]]></code>
     </RedundantCastGivenDocblockType>
-    <UndefinedInterfaceMethod occurrences="4">
+    <UndefinedInterfaceMethod>
       <code>$psr7</code>
       <code>get</code>
       <code>get</code>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -4,6 +4,9 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    findUnusedPsalmSuppress="true"
+    findUnusedBaselineEntry="true"
+    findUnusedCode="true"
     errorBaseline="psalm-baseline.xml"
 >
     <projectFiles>


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   |no
| RFC           | no
| QA            | yes

### Description
- Drop php 8.0 in preparation for phpunit 10.
- Drop obsolete composer conflicts.
- Bump dependencies
- Remove obsolete platform ignore from ci config.
